### PR TITLE
Move content from app-components and align

### DIFF
--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -704,12 +704,81 @@ struct {
 
 # Security Considerations
 
-TODO Security
+This entire document focuses on authorization policy.
+TODO More Security
 
 
 # IANA Considerations
 
-This document has no IANA actions.
+## New MIMI Role Capabilities registry
+
+Create a new registry with the following values assigned sequentially using the reference RFCXXXX.
+
+~~~
+canAddParticipant
+canRemoveParticipant
+canAddOwnClient
+canRemoveSelf
+canAddSelf
+canCreateJoinCode - reserved for future use
+canUseJoinCode
+canBan
+canUnBan
+canKick
+canKnock
+canAcceptKnock
+canChangeUserRole
+canChangeOwnRole
+canCreateSubgroup
+canSendMessage
+canReceiveMessage
+canCopyMessage
+canReportAbuse
+canReactToMessage
+canEditReaction
+canDeleteReaction
+canEditOwnMessage
+canDeleteOwnMessage
+canDeleteAnyMessage
+canStartTopic
+canReplyInTopic
+canEditTopic
+canSendDirectMessage
+canTargetMessage
+canUploadImage
+canUploadVideo
+canUploadAttachment
+canDownloadImage
+canDownloadVideo
+canDownloadAttachment
+canSendLink
+canSendLinkPreview
+canFollowLink
+canCopyLink
+canChangeRoomName
+canChangeRoomDescription
+canChangeRoomAvatar
+canChangeRoomSubject
+canChangeRoomMood
+canChangeOwnName
+canChangeOwnPresence
+canChangeOwnMood
+canChangeOwnAvatar
+canStartCall
+canJoinCall
+canSendAudio
+canReceiveAudio
+canSendVideo
+canReceiveVideo
+canShareScreen
+canViewSharedScreen
+canChangeRoomMembershipStyle
+canChangeRoleDefinitions
+canChangePreauthorizedUserList
+canChangeMlsOperationalPolicies
+canDestroyRoom
+canSendMLSReinitProposal
+~~~
 
 
 --- back

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -69,53 +69,53 @@ exactly one role. By virtue of a user's credential, a user might also be
 
 {::boilerplate bcp14-tagged}
 
-Room ID:
+**Room ID**:
 An identifier which uniquely identifies a room.
 
-User ID:
+**User ID**:
 An internal identifier which uniquely identifies a user.
 
-Nickname:
+**Nickname**:
 The identifier by which a user is referred inside a room. Depending on the context it may be a display name, handle, pseudonym, or temporary identifier. The nickname in one room need not correlate with the nickname for the same user in a different room.
 
-Client ID:
+**Client ID**:
 An internal identifier which uniquely identifies one client/device instance of one user account.
 
-Persistent vs. Temporary rooms:
-A temporary room is destroyed when the last occupant exits whereas a persistent room is not destroyed when the last occupant exist. As MLS has no notion of a group with no members, a persistent room could consist of a sequence of distinct MLS groups, zero or one of which would exist at a time.
+**Persistent vs. Temporary rooms**:
+A temporary room is no longer joinable once the last participant exits whereas a persistent room is not destroyed when the last participant exist. As MLS has no notion of a group with no members, a persistent room could consist of a sequence of distinct MLS groups, zero or one of which would exist at a time.
 
 ## Moderation Terms
 
-Knock:
+**Knock**:
 To request entry into a room.
 
-Ban:
-To remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has a role of "outcast". Typically this action is only used in an open or semi-open room. It is distinct than merely removing a user from an administered group.
+**Ban**:
+To remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). It is distinct from merely removing a user from a room.
 
-Kick:
-To temporarily remove a participant or visitor from a room. The user is allowed to re-enter the room at any time.
+**Kick**:
+To temporarily remove a participant's clients from a room. The user is allowed to re-enter the room at any time.
 
-Voice (noun):
+**Voice (noun)**:
 The privilege to send messages in a room.
 
-Revoke Voice:
+**Revoke Voice**:
 To remove the permission to send messages in a room.
 
-Grant Voice:
+**Grant Voice**:
 To grant the permission to send messages in a room.
 
-# Room Capabilities
+## Room Capabilities
 
-**Membership-Style**:
+**Membership-Approach**:
 The overall approach of membership authorization in a room, which could be open, members-only (administrated), fixed-membership, or parent-dependent.
 
-- **Open room**: An open room can be joined by any non-banned user.
+- **Open room**: Typically an open room can be joined by any non-banned user. It can be represented solely by a permissive set of roles as defined in {{roles}}.
 
-- **Members-Only room**: A members-only room can only be joined by a user in the occupant list, or who is pre-authorized. Authorized users can add or remove users to the room. In an enterprise context, it is also common (but not required) for users from a particular domain, group, or workgroup to be pre-authorized to add themselves to a Members-Only room.
+- **Members-Only room**: A members-only room can only be joined by a user in the particpant list, or who is pre-authorized. Authorized users can add or remove users to the room. In an enterprise context, it is also common (but not required) for users from a particular domain, group, or workgroup to be pre-authorized to add themselves to a Members-Only room. It can be represented solely by a set of less permissive roles as defined in {{roles}}.
 
-- **Fixed-Membership room**: Fixed-membership rooms have the list of occupants specified when they are created. Other users cannot be added. Occupants cannot leave or be removed, however a user can remove all its clients from the associated MLS group. The most common case of a fixed-membership room is a 1:1 conversation. This room membership style is used to implement Direct Message (DM) and Group DM features. Only a single fixed-membership room can exist for any unique set of occupants.
+- **Fixed-Membership room**: Fixed-membership rooms have the list of participants specified when they are created. Other users cannot be added. Ordinary users cannot leave or be removed, however a user can remove all its clients from the associated MLS group. The most common case of a fixed-membership room is a 1:1 conversation. This room membership style is used to implement Direct Message (DM) and Group DM features. Only a single fixed-membership room can exist for any unique set of participants.
 
-- **Parent-dependent room**: In a parent-dependent room, the list occupants of the room must be a strict subset of the occupants of the parent room. If a user leaves or is removed from the parent room, that user is automatically removed from any parent-dependent rooms of that parent.
+- **Parent-dependent room**: In a parent-dependent room, the list participants of the room must be a strict subset of the participants of the parent room. If a user leaves or is removed from the parent room, that user is automatically removed from any parent-dependent rooms of that parent.
 
 <!--
 Multi-device vs. Single-device:
@@ -316,40 +316,6 @@ struct {
 
 If persistent_room is false, the room will be automatically inaccsessible when the corresponding MLS group is destroyed (when there are no clients in the group). If persistent_room is true, the room policy will remain and a client whose user has appropriate authorization can create a new MLS group for the same room. (There is not a 1:1 correlation of MLS group to room ID in a persistent room.)
 
-## Pre-authorized users
-
-~~~
-enum {
-  reserved(0),
-  system(1),
-  owner(2),
-  admin(3),
-  regular_user(4),
-  visitor(5),
-  banned(6),
-  (255)
-} Role;
-
-struct {
-  Role target_role;
-  /* preauth_domain consists of ASCII letters, digits, and hyphens */
-  opaque preauth_domain<V>;
-  /* the remaining fields are in the form of a URI */
-  opaque preauth_workgroup<V>;
-  opaque preauth_group<V>;
-  opaque preauth_user<V>;
-} PreAuthPerRoleList;
-
-struct {
-  ...
-  PreAuthPerRoleList pre_auth_list<V>;
-  ...
-} RoomPolicy;
-~~~
-
-In members-only rooms, it is convenient to pre-authorize specific users--or users from specific domains, workgroups/teams, and groups--to specific roles. The workgroup, group, and user are expressed as a Uri. The domain is expressed in US-ASCII letters, digits, and hyphens only. If the domain is internationalized, the Internationalized Domain Names {{!RFC5890}} conversion MUST be done before filling in this value.
-
-Note that the system role is used to authorize external proposals for operations for other users. For example, the system role can be used to authorize a provider to remove clients from groups when the corresponding user account is deleted.
 
 ## Delivery and Read notifications, Pseudonyms
 
@@ -424,21 +390,21 @@ struct {
 } RoomPolicy;
 ~~~
 
-### Link policies
+## Link policies
 
 If discoverable is true, the room is searchable. Presumably this means the the only way to join the room in a client user interface is to be added by an administrator or to use a joining link.
 Inside the LinkPolicy are several fields that describe the behavior of links.If the on_request field is true, no joining link will be provided in the room policy; the client will need to fetch a joining link out-of-band or generate a valid one for itself. If present, the URI in link_requests can be used by the client to request an invite code. The value of join_link is empty and the other fields are ignored.If the on_request field is false, the join_link field will contain a joining link. If the link will work for multiple users, multiuser is true. The expiration field represents the time, in seconds after the start of the UNIX epoch (1-January-1970) when the link will expire. The link_requests field can be empty.
 
-### Logging policies
+## Logging policies
 
 Inside the LoggingPolicy, the logging field can be forbidden, optional, or required. If logging is forbidden then the other fields are empty. If logging is required, the list of logging_clients needs to contain at least one logging URI. Each provider should have no more than one logging client at a time in a room. The machine_readable_policy and human_readable_policy fields optionally contain pointers to the owning provider's machine readable and human readable logging policies, respectively. If logging is optional and there is at least one logging_client then logging is active for the room.
 
-### Chat history policies
+## Chat history policies
 
 Inside the HistoryPolicy, if history_sharing is forbidden, this means that clients (including bots) are expected to not to share chat history with new joiners, in which case who_can_share is empty, automatically_share is false, and max_time_period is zero.
 Otherwise who_can_share is a list of roles that are authorized to share history (for example, only admins and owners can share). The values of none and outcast cannot be used in who_can_share. If automatically_share is true, clients can share history with new joiners without user initiation. The history that is shared is limited to max_time_period seconds worth of history.
 
-### Chat bot policies
+## Chat bot policies
 
 Inside the RoomPolicy there is a list of allowed_bots. Each of which has several fields. The name, description, and homepage are merely descriptive. The bot_role indicates if the chat bot would be treated as a system-user, owner, admin, regular_user, or visitor.
 The can_read and can_write fields indicate if the chat bot is allowed to read messages or send messages in the MLS group, respectively. If can_target_message_in_group is true it indicates that the chat bot can send an MLS targeted message (see Section 2.2 of [I-D.ietf-mls-extensions]) or use a different conversation or out-of-band channel to send a message to specific individual users in the room. If per_user_content is true, the chat bot is allowed to send messages with distinct content to each member. (For example a poker bot could deal a different hand to each user in a chat).Users could set policies to reject or leave groups with bots rights that are inconsistent with the user's privacy goals.
@@ -537,7 +503,6 @@ The membership capabilities below allow authorized holders to update the Partici
     In addition, the action MUST respect both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the added user's target role.
 
 - `canUseJoinCode` - the holder of this capability can externally join a room using a join code for that room, provided the join code is valid, the join code refers to a valid target role, and both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) constraints are respected.
-
 
 - `canRemoveParticipant` - the holder of this capability can propose a) the removal of another user (excluding itself) from the participant list, and b) removal of all of that user's clients, as a single action.
   There MUST NOT be any clients of the removed user in the MLS group after the corresponding commit.
@@ -675,7 +640,7 @@ The following capability names are reserved for possible future use
   - external proposal - general operational policy rules
   - external commit - general operational policy rules
 
-## Extensibility of the policy format
+# Extensibility of the policy format
 
 Finally, The extensibility mechanism allows for future addition of new room policies.
 
@@ -701,7 +666,6 @@ struct {
 ~~~
 
 
-
 # Security Considerations
 
 This entire document focuses on authorization policy.
@@ -709,6 +673,14 @@ TODO More Security
 
 
 # IANA Considerations
+
+## Preauthorized users MLS application component
+
+TBC
+
+## Role definitions MLS application component
+
+TBC
 
 ## New MIMI Role Capabilities registry
 

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -1327,32 +1327,10 @@ enum {
 } Optionality;
 
 enum {
-  reserved(0),
-  system(1),
-  owner(2),
-  admin(3),
-  regular_user(4),
-  visitor(5),
-  banned(6),
-  (255)
-} Role;
-
-struct {
-  Role target_role;
-  /* preauth_domain consists of ASCII letters, digits, and hyphens */
-  opaque preauth_domain<V>;
-  /* the remaining fields are in the form of a URI */
-  opaque preauth_workgroup<V>;
-  opaque preauth_group<V>;
-  opaque preauth_user<V>;
-} PreAuthPerRoleList;
-
-enum {
   reserved(0)
-  open(1),
-  members-only(2),
-  fixed-membership(3),
-  parent-dependent(4),
+  ordinary(1),
+  fixed-membership(2),
+  parent-dependent(3),
   (255)
 } MembershipStyle;
 
@@ -1407,10 +1385,6 @@ struct {
 struct {
   MembershipStyle membership_style;
   bool multi_device;
-  bool knock_allowed;
-  bool moderated;
-  bool password_protected;
-  PreAuthPerRoleList pre_auth_list<V>;
   Uri parent_room_uri;
   bool persistent_room;
   Optionality delivery_notifications;
@@ -1426,14 +1400,6 @@ struct {
 
 RoomPolicy room_policy;
 ~~~
-
-# Example Roles and Permissions scheme
-
-- Owner
-- Admin
-- Moderator
-- Ordinary-user
-- Guest
 
 
 # Acknowledgments

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -58,20 +58,16 @@ and clients can support different policies and capabilities across vendors
 and providers. Our goal is to balance the policy and authorization goals of
 the room with the policy and authorization goals of the end user, so we can support a broad range of vendors and providers.
 
-Each room is owned by one provider at a time. The owning provider controls the range of acceptable policies. The user responsible for the room can further choose among the acceptable policies. Users (regardless if on other providers) can either accept the policies of the room or not. However we want to make it as easy as possible for clients from other providers to comply with the room policy primitives without enumerating specific features or requiring all clients implementations to present an identical user experience.
+Each room is owned by one provider at a time. The owning provider controls the range of acceptable policies. The user responsible for the room can further choose among the acceptable policies. Users (regardless if on other providers) can either accept the policies of the room or not.
 
-Configurable Role-based access control with permissions. An example
-scheme is described in the Appendix.
+However we want to make it as easy as possible for clients from other providers to comply with the room policy primitives without enumerating specific features or requiring all clients implementations to present an identical user experience. An important aspect of this is the system of configurable Role-based access control with granular capabilities per role (described in {{roles}}).
+Each user in the participant list (defined in {{!I-D.ietf-mimi-protocol}}) has
+exactly one role. By virtue of a user's credential, a user might also be
+*preauthorized* with a specific role as described in {{preauthorized-users}}.
 
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}
-
-Role:
-A long-lived position reflecting the privilege level of a participant in a room. Possible values are owner, admin, regular-user, visitor, none, or outcast. A role closely maps to the MUC concept of affiliation, not the MUC concept of role.
-
-Occupant:
-A user that has at least one client in the corresponding MLS group, and a role of owner, admin, regular-user, or visitor.
 
 Room ID:
 An identifier which uniquely identifies a room.
@@ -85,7 +81,7 @@ The identifier by which a user is referred inside a room. Depending on the conte
 Client ID:
 An internal identifier which uniquely identifies one client/device instance of one user account.
 
-**Persistent vs. Temporary rooms**:
+Persistent vs. Temporary rooms:
 A temporary room is destroyed when the last occupant exits whereas a persistent room is not destroyed when the last occupant exist. As MLS has no notion of a group with no members, a persistent room could consist of a sequence of distinct MLS groups, zero or one of which would exist at a time.
 
 ## Moderation Terms
@@ -108,73 +104,200 @@ To remove the permission to send messages in a room.
 Grant Voice:
 To grant the permission to send messages in a room.
 
-Moderator:
-A client whose user has a role of admin or owner in the room. A moderator can ban users, and (when allowed in the room) can grant and revoke voice, kick individual clients, and grant access (ex: in response to a knock).
-
 # Room Capabilities
 
-Membership-Style:
+**Membership-Style**:
 The overall approach of membership authorization in a room, which could be open, members-only (administrated), fixed-membership, or parent-dependent.
 
-Open room:
-An open room can be joined by any non-banned user.
+- **Open room**: An open room can be joined by any non-banned user.
 
-Members-Only room:
-A members-only room can only be joined by a user in the occupant list,
-or who is pre-authorized. Authorized users can add or remove users to the
-room. In an enterprise context, it is also common (but not required) for
-users from a particular domain, group, or workgroup to be pre-authorized to
-add themselves to a Members-Only room.
+- **Members-Only room**: A members-only room can only be joined by a user in the occupant list, or who is pre-authorized. Authorized users can add or remove users to the room. In an enterprise context, it is also common (but not required) for users from a particular domain, group, or workgroup to be pre-authorized to add themselves to a Members-Only room.
 
-Fixed-Membership room:
-Fixed-membership rooms have the list of occupants specified when they are created. Other users cannot be added. Occupants cannot leave or be removed, however a user can remove all its clients from the associated MLS group. The most common case of a fixed-membership room is a 1:1 conversation. This room membership style is used to implement Direct Message (DM) and Group DM features. Only a single fixed-membership room can exist for any unique set of occupants.
+- **Fixed-Membership room**: Fixed-membership rooms have the list of occupants specified when they are created. Other users cannot be added. Occupants cannot leave or be removed, however a user can remove all its clients from the associated MLS group. The most common case of a fixed-membership room is a 1:1 conversation. This room membership style is used to implement Direct Message (DM) and Group DM features. Only a single fixed-membership room can exist for any unique set of occupants.
 
-Parent-dependent room:
-In a parent-dependent room, the list occupants of the room must be a strict subset of the occupants of the parent room. If a user leaves or is removed from the parent room, that user is automatically removed from any parent-dependent rooms of that parent.
+- **Parent-dependent room**: In a parent-dependent room, the list occupants of the room must be a strict subset of the occupants of the parent room. If a user leaves or is removed from the parent room, that user is automatically removed from any parent-dependent rooms of that parent.
 
+<!--
 Multi-device vs. Single-device:
 A multi-device room can have multiple simultaneous clients of the same user as participants in the room. A single-device room can have a maximum of one client per user in the room at any moment.
 
 Knock-Enabled vs. Knock-Disabled:
 In a knock-enabled room, non-banned users are allowed to programmatically request entry into the room. In a knock-disabled room this functionality is disabled.
+-->
 
-Moderated vs. Unmoderated:
-An an unmoderated room, any occupant can send messages to the room. In a moderated room, only occupants who have "voice" can send messages to the room.
+# Role-Based Access Control {#roles}
 
-# Room policy format syntax
+The Role-Based Access Control component contains a list of all the roles in the room, and the capabilities associated with them.
+It contains a `role_index`, which is used to refer to the role elsewhere. (Note that role indexes might not be contiguous.)
+The `role_index` zero is reserved to refer to a participant that does not (yet) or no longer appears (or will no longer appear) in the participant list.
+
+The component also contains a `role_name` (a human-readable text string name for the
+role), and a `role_description` (another string, which can have zero length).
+
+Each Role also can contain constraints on the minimum and maximum number of participants, and the minimum and maximum number of active participants.
+If the minimum number is zero, there is no minimum number of participants for that particular role.
+If there is no maximum number of participants for a particular role, that parameter is absent.
+
+>If the maximum number of active participants is zero, then no participants are allowed to have clients in the room's MLS group.
+
+The `authorized_role_changes` field is used to provide fine-grained control about which transitions are allowed when adding and removing participants and when moving participants to new roles, including banning/unbanning, and promoting/demoting to or from roles with moderator or administrator privileges.
+A more detailed discussion is in the description of the specific capabilities in the next section.
+
+>This design results in each participant only having a single role at a time, with a single list of capabilities and an explicit list of allowed role transitions. It makes the authorization process for a verifier consistent regardless of the complexity of the set of authorization rules.
+
+Some examples are provided in {{role-examples}}.
+
+RoleData is the format of the `data` field inside the ComponentData struct for the Role-Based Access Control component in the `app_data_dictionary` GroupContext extension defined in {{!I-D.ietf-mls-extensions}}.
+
+~~~ tls-presentation
+/* See MIMI Capability Types IANA registry */
+uint16 CapablityType;
+
+struct {
+   uint32 from_role_index;
+   uint32 target_role_indexes<V>;
+} SingleSourceRoleChangeTargets;
+
+struct {
+  uint32 role_index;
+  opaque role_name<V>;
+  opaque role_description<V>;
+  CapabilityType role_capabilities<V>;
+  uint32 minimum_participants_constraint;
+  optional uint32 maximum_participants_constraint;
+  uint32 minimum_active_participants_constraint;
+  optional uint32 maximum_active_participants_constraint;
+  SingleSourceRoleChangeTargets authorized_role_changes<V>;
+} Role;
+
+struct {
+  Role roles<V>;
+} RoleData;
+
+RoleData RoleUpdate;
+~~~
+
+RoleUpdate (which has the same format as RoleData) is the format of the `update` field inside the AppDataUpdate struct in an AppDataUpdate Proposal for the Role-Based Access Control component.
+If the contents of the `update` field are valid and if the proposer is authorized to generate such an update, the value of the `update` field completely replaces the value of the `data` field.
+
+>Note that in the MIMI environment, changing the definitions of roles is anticipated to be very rare over the lifetime of a room (for example changing a room which has grown dramatically from cooperatively managed by all participants to explicitly moderated or administered).
+
+Changing Role definitions is sufficiently disruptive, that an update to this component is not valid if it appear in the same commit as any Participant List change.
+
+
+# Preauthorized Users
+
+Preauthorized users are MIMI users and external senders that have authorization to adopt a role in a room by virtue of certain credential claims or properties, as opposed to being individually enumerated in the participant list.
+For example, a room for employee benefits might be available to join with the regular participant role to all full-time employees with a residence in a specific country; while anyone working in the human resources department might be able to join the same room as a moderator.
+This data structure is consulted in two situations: for external joins (external commits) and external proposals when the requester does not already appear in the participant list; and separately when an existing participant explicitly tries to change its *own* role.
+
+>Only consulting Preauthorized users in these cases prevents several attacks. For example, it prevents an explicitly banned user from rejoining a group based on a preauthorization.
+
+PreAuthData is the format of the `data` field inside the ComponentData struct for the Preauthorized Participants component in the `application_data` GroupContext extension.
+
+The individual `PreAuthRoleEntry` rules in `PreAuthData` are consulted one at a time.
+A `PreAuthRoleEntry` matches for a requester when every `Claim.claim_id` has a corresponding claim in the requester's MLS Credential which exactly matches the corresponding `claim_value`.
+When the rules in a Preauthorized users struct match multiple roles, the requesting client receives the first role which matches its claims.
+
+
+~~~ tls-presentation
+struct {
+  /* MLS Credential Type of the "claim"  */
+  CredentialType credential_type;
+  /* the binary representation of an X.509 OID, a JWT claim name  */
+  /* string, or the CBOR map claim key in a CWT (an int or tstr)  */
+  opaque id<V>;
+} ClaimId;
+
+struct {
+  ClaimId claim_id;
+  opaque claim_value<V>;
+} Claim;
+
+struct {
+  /* when all claims in the claimset are satisfied, the claimset */
+  */ is satisfied */
+  Claim claimset<V>;
+  Role target_role;
+} PreAuthRoleEntry;
+
+struct {
+  PreAuthRoleEntry preauthorized_entries<V>;
+} PreAuthData;
+
+PreAuthData PreAuthUpdate;
+~~~
+
+<!--
+struct {
+  select (Credential.credential_type) {
+    case basic:
+        struct {}; /* only identity */
+    case x509:
+        /* ex: subjectAltName (2.5.29.17) = hex 06 03 55 1d 1e */
+        opaque oid<V>;
+        /* for sequence or set types, the specific item (1-based) */
+        /* in the collection. zero means any item in a collection */
+        uint8 ordinal;
+    case jwt:
+        opaque json_path<V>;
+    case cwt:
+        CborKeyNameOrArrayIndex cbor_path<V>;
+  };
+} Claim;
+
+struct {
+    /* a CBOR CDE encoded integer, tstr, bstr, or tagged version of */
+    /* any of those map key types. Ex: -1 = 0x20, "hi" = 0x626869,  */
+    /* 1(3600) = 0xC1190E10 */
+    opaque cbor_encoded_claim<V>;
+    optional uint array_index;
+} CborKeyNameOrArrayIndex;
+-->
+
+PreAuthUpdate (which has the same format as PreAuthData) is the format of the `update` field inside the AppDataUpdate struct in an AppDataUpdate Proposal for the Preauthorized Participants component.
+If the contents of the `update` field are valid and if the proposer is authorized to generate such an update, the value of the `update` field completely replaces the value of the `data` field.
+
+>As with the definition of roles, in MIMI it is not expected that the definition of Preauthorized users would change frequently. Instead the claims in the underlying credentials would be modified without modifying the preauthorization policy.
+
+Changing Preauthorized user definitions is sufficiently disruptive, that an update to this component is not valid if it appears in the same commit as any Participant List change, except for user removals.
+
+Because the Preauthorized users component usually authorizes non-members, it is also a natural choice for providing concrete authorization for policy enforcing systems incorporated into or which run in coordination with the MIMI Hub provider or specific MLS Distribution Services. For example, a preauthorized role could allow the Hub to remove participants and to ban them, but not to add any users or devices. This unifies the authorization model for members and non-members.
+
+
+# Base Room policy format syntax
 
 ## Membership-related policy
 
-The `membership_style` of a room can be one of the following values:
+> **TODO**: refactor membership_style to be constraints to the role-based access control system
 
-- open
-- members-only (default)
+The `membership_style` of a room can express some additional constraints on
+membership transitions in a room. It can have one of the following values:
+
+- ordinary (default)
 - fixed-membership
 - parent-dependent
 
 ~~~
 enum {
   reserved(0)
-  open(1),
-  members-only(2),
-  fixed-membership(3),
-  parent-dependent(4),
+  ordinary(1),
+  fixed-membership(2),
+  parent-dependent(3),
   (255)
 } MembershipStyle;
 ~~~
 
-An open room allows any unbanned user. A members-only room allows only
-invited or preauthorized users to join. A fixed-membership room (which can
-be used for DMs or Group DMs) has a list of authorized users set at creation
+An ordinary room has no constraints beyond those of the role-based access control system. A fixed-membership room (which can
+be used for DMs or Group DMs) has a participant list set once at creation
 time that cannot be added to. A parent-dependent room always has a strict subset of the participants of its parent room.
 
 If the membership_style is `parent-dependent` the `parent_room_uri` MUST be set with the room ID of the parent. Otherwise the field is zero-length.
 
 If `multi_device` is true (the default), the MLS group may contain multiple clients per user. If false only a single client can be an MLS member at one time.
 
-If `knock_allowed` is true, a non-participant can send a knock requesting access to the target room. If false, a user cannot. This option can only be enabled if the membership_style is members-only. The default is false.
-
-If `moderated` is true, the room supports granting and revoking voice. The default is false.
+<!--If `knock_allowed` is true, a non-participant can send a knock requesting access to the target room. If false, a user cannot. This option can only be enabled if the membership_style is members-only. The default is false.
+-->
 
 ~~~
 enum {
@@ -186,17 +309,12 @@ struct {
   MembershipStyle membership_style;
   Uri parent_room_uri<V>;
   bool multi_device;
-  bool knock_allowed;
-  bool moderated;
   bool persistent_room;
-  bool password_protected;
   ...
-} RoomPolicy;
+} BaseRoomPolicy;
 ~~~
 
-If persistent_room is false, the room will be automatically deleted when the corresponding MLS group is destroyed (when there are no clients in the group). If persistent_room is true, the room policy will remain and a client whose user has appropriate authorization can create a new MLS group for the same room. (There is not a 1:1 correlation of MLS group to room ID in a persistent room.)
-
-If password_protected is true, the room requires a passcode or passphrase when a client of a new user requests access to the GroupInfo used to join a group. The default is false.
+If persistent_room is false, the room will be automatically inaccsessible when the corresponding MLS group is destroyed (when there are no clients in the group). If persistent_room is true, the room policy will remain and a client whose user has appropriate authorization can create a new MLS group for the same room. (There is not a 1:1 correlation of MLS group to room ID in a persistent room.)
 
 ## Pre-authorized users
 
@@ -325,175 +443,6 @@ Otherwise who_can_share is a list of roles that are authorized to share history 
 Inside the RoomPolicy there is a list of allowed_bots. Each of which has several fields. The name, description, and homepage are merely descriptive. The bot_role indicates if the chat bot would be treated as a system-user, owner, admin, regular_user, or visitor.
 The can_read and can_write fields indicate if the chat bot is allowed to read messages or send messages in the MLS group, respectively. If can_target_message_in_group is true it indicates that the chat bot can send an MLS targeted message (see Section 2.2 of [I-D.ietf-mls-extensions]) or use a different conversation or out-of-band channel to send a message to specific individual users in the room. If per_user_content is true, the chat bot is allowed to send messages with distinct content to each member. (For example a poker bot could deal a different hand to each user in a chat).Users could set policies to reject or leave groups with bots rights that are inconsistent with the user's privacy goals.
 
-## Extensibility of the policy format
-
-Finally, The extensibility mechanism allows for future addition of new room policies.
-
-~~~
-enum {
-  null(0),
-  boolean(1),
-  number(2),
-  string(3),
-  jsonObject(4)
-} ExtType;
-
-struct {
-  opaque name<V>;
-  ExtType type;
-  opaque value<V>;
-} PolicyExtension;
-
-struct {
-  ...
-  PolicyExtension policy_extensions<V>;
-} RoomPolicy;
-~~~
-
-foo
-
-
-# Role-Based Access Control
-
-With Role-Based Access Control, the room policy defines a list of roles and the capabilities associated with each role.
-
-~~~
-enum {
-  reserved(0),
-  canAddParticipant(1),
-  ...
-  (65535)
-} Capability;
-
-struct {
-  int role_index;
-  opaque role_name<V>;
-  opaque role_description<V>;
-  Capability role_capabilities<V>;
-  int minimum_participants_constraint;
-  optional int maximum_participants_constraint;
-  int minimum_active_participants_constraint;
-  optional int maximum_active_participants_constraint;
-} Role
-
-struct {
-  Role target_role;
-  /* preauth_domain consists of ASCII letters, digits, and hyphens */
-  opaque preauth_domain<V>;
-  /* the remaining fields are in the form of a URI */
-  opaque preauth_workgroup<V>;
-  opaque preauth_group<V>;
-  opaque preauth_user<V>;
-} PreAuthPerRoleList;
-
-struct {
-  Role roles<V>;
-  ...
-  PreAuthPerRoleList pre_auth_list<V>;
-  ...
-} RoomPolicy;
-~~~
-
-## Capability Categories
-
-### Membership Capabilities
-
-- canAddParticipant
-- canRemoveParticipant
-- canAddOwnClient
-- canRemoveSelf
-- canAddSelf
-- canCreateJoinLink
-- canUseJoinLink
-
-These actions are subject to role constraints described below.
-
-### Moderation Capabilities
-
-- canBan
-- canUnBan
-- canKick
-- canRevokeVoice
-- canGrantVoice
-- canKnock
-- canAcceptKnock
-- canChangeUserRole
-- canCreateSubgroup
-
-These actions are subject to role constraints described below.
-
-### Breakouts
-
-- canSendDirectMessage
-- canTargetMessage
-
-### Message Capabilities
-
-- canSendMessage
-- canReceiveMessage
-- canReportAbuse
-- canReactToMessage
-- canEditReaction
-- canDeleteReaction
-- canEditOwnMessage
-- canDeleteOwnMessage
-- canDeleteAnyMessage
-- canStartTopic
-- canReplyInTopic
-- canSendDirectMessage
-- canTargetMessage
-
-The Hub can enforce whether a member can send a message and not fanout application messages. Other capabilities can only be enforced by other clients.
-
-
-### Asset Capabilities
-
-- canUploadImage
-- canUploadVideo
-- canUploadAttachment
-- canDownloadImage
-- canDownloadVideo
-- canDownloadAttachment
-- canSendLink
-- canSendLinkPreview
-- canFollowLink
-
-### Adjust metadata
-
-- canChangeRoomName
-- canChangeRoomSubject
-- canChangeRoomAvatar
-- canChangeOwnName
-- canChangeOwnPresence
-- canChangeOwnMood
-- canChangeOwnAvatar
-
-### Real-time media
-
-- canStartCall
-- canJoinCall
-- canSendAudio
-- canReceiveAudio
-- canSendVideo
-- canReceiveVideo
-- canShareScreen
-- canViewSharedScreen
-
-### Disruptive Policy Changes
-
-- canChangeRoomMembershipStyle
-- canChangeOtherPolicyAttribute
-- canDestroyRoom
-- MLS specific
-  - update
-  - reinit
-  - PSK
-  - external proposal
-  - external commit
-
-## Role constraints
-
-Minimum and maximum number of each role.
 
 # Operational policy
 
@@ -559,154 +508,198 @@ What Additional authenticated data, can/should be sent unencrypted in an otherwi
 Application-level identifiers of public key material (specifically the application_id extension as defined in Section 5.3.3 of [RFC9420]).
 
 
-# Some types of rooms with RBAC
+# Role Capabilities
 
-## Strict administrator policy
+As described in {{roles}}, each role has a list of capabilities, which in rare cases could be empty.
+When we say that the holder of a capability can take some action, we mean that whatever entity is taking the action (a participant, a potential future participant, or an external party) has a specific entry in the Participant List struct and a corresponding role--or is preauthorized to take action with a specific role via the Preauthorized Users struct--and that the `role_capabilities` list contains the relevant capability.
 
-Role levels (low to high capabilities):
+Unless otherwise specified, capabilities apply both to sending a set of consistent MLS proposals that could be committed by any member of the corresponding MLS group, and to sending an MLS commit containing a set of consistent MLS proposals.
 
-- banned
-- guest
-- ordinary_user
-- group_admin
-- super_admin
+## Membership Capabilities
 
-Capabilities per role
+The membership capabilities below allow authorized holders to update the Participant list, or change the active participants (by removing and adding MLS clients corresponding to those participants), or both.
 
-- banned
-    - (no capabilities)
-- guest
-	- canSendMessage
-	- canReceiveMessage
-	- canRemoveSelf
-- ordinary_user
-    - (everything guest can do, plus:)
-	- canAddOwnClient
-	- canChangeOwnName,Presence,Mood,Avatar
-	- canReport
-	- canSendLinks
-    - canSendImages
-    - canSendVideos
-- group_admin
-	- (everything ordinary_user can do, plus:)
-	- canSendAttachments
-	- canAddParticipant
-	- canRemoveParticipant
-	- canBanish - promote
-	- canUnBanish
-	- canKick
-	- canChangeRoomName,Subject,Avatar
-	- canPromoteRole(from=[ordinary]; to=[admin])
-	- canDemoteRole([from=[admin], to=[ordinary])
-	- canDestroyRoom
-	- canCreateJoinLink
-- super_admin
-    - (everything group_admin can do, plus:)
-    - canPromoteRole(from=[ordinary,admin], to=[superadmin])
-    - canDemoteRole(from=[superadmin], to=[ordinary,admin])
-    - canChangeRoomMembershipStyle
+- `canAddParticipant` - the holder of this capability can add another user, that is not already in the participant list, to the participant list.
+  (This capability does not apply to the holder adding itself.)
+  The `authorized_role_changes` list in the holder's role is consulted to authorize the added user's target role.
+  The `authorized_role_changes` list MUST have an entry where the `authorized_role_changes.from_role_index` equals zero, and that entry's `target_role_indexes` list includes the target role.
+  The proposed action is only authorized if the action respects both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the added user's target role.
+  When the participant list addition for the target role is authorized, the holder is also authorized to add any MLS clients matching the added user to the room's MLS group .
 
-Role constraints: must have at least 1 "admin"
+- `canAddOwnClient` - a holder of this capability that is in the participant list, can add its own client (via an external commit or external proposal); and can add other clients that share the same user identity (via Add proposals) if the holder's client is already a member of the corresponding MLS group.
 
-## Cooperative room (everyone can add and remove)
+- `canAddSelf` - the holder of this capability can use an external commit or external proposal to add itself to the participant list.
+  (The holder MUST NOT already appear in the participant list).
+  Its usage differs slightly based on in which role it appears.
+  - When `canAddSelf` appears on role zero, any user who is not already in the participant list can add itself, with certain provisions. The holder consults the `authorized_role_changes` list for an entry with `from_role_index` equal to zero. The holder can add itself with any non-zero `target_role_indexes` from that entry, if the action respects both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the added user's target role.
+  - When `canAddSelf` appears on a non-zero role, a client can only become the holder of this capability via the Preauthorized users mechanism.
+    The `authorized_role_changes` list in the target role MUST have an entry where the `from_role_index` is zero and the `target_role_indexes` contains the target role.
+    In addition, the action MUST respect both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the added user's target role.
 
-Role levels (low to high capabilities):
-
-- banned
-- ordinary_user
-- group_admin
-- super_admin
-
-Capabilities per role
-
-- banned
-    - (no capabilities)
-- ordinary_user
-	- canSendMessage
-	- canReceiveMessage
-	- canRemoveSelf
-	- canAddOwnClient
-	- canChangeOwnName,Presence,Mood,Avatar
-	- canReport
-	- canAddParticipant
-	- canRemoveParticipant
-	- canKick
-	- canChangeRoomName,Subject,Avatar
-	- canCreateJoinLink
-	- canSendLinks
-    - canSendImages
-    - canSendVideos
-    - canSendAttachments
-- group_admin
-	- (everything ordinary_user can do, plus:)
-	- canBanish
-	- canUnBanish
-	- canPromoteRole(from=[ordinary], to=[admin])
-	- canDemoteRole([from=[admin], to=[ordinary])
-	- canDestroyRoom
-- super_admin
-    - (everything group_admin can do, plus:)
-    - canPromoteRole(from=[ordinary,admin], to=[superadmin])
-    - canDemoteRole(from=[superadmin], to=[ordinary,admin])
-    - canChangeRoomMembershipStyle
-
-Role constraints: must have at least 1 "group_admin"
+- `canUseJoinCode` - the holder of this capability can externally join a room using a join code for that room, provided the join code is valid, the join code refers to a valid target role, and both the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) constraints are respected.
 
 
-## Moderated room
+- `canRemoveParticipant` - the holder of this capability can propose a) the removal of another user (excluding itself) from the participant list, and b) removal of all of that user's clients, as a single action.
+  There MUST NOT be any clients of the removed user in the MLS group after the corresponding commit.
+  A proposer holding this capability consults its role's `authorized_role_changes` entries for an entry where `from_role_index` matches the target user's current role; if the `target_role_indexes` for that entry contains zero, and the `minimum_participants_constraint` and `minimum_active_participants_constraint` are satisfied, the proposal is authorized.
 
-Role levels (low to high capabilities):
+- `canRemoveOwnClient` - the holder of this capability can propose to remove its own client using an MLS Remove or SelfRemove proposal without changing the Participant list.
+  Due to restrictions in MLS which insure the consistency of the group, this action cannot be committed by the leaving user.
+  If the `minimum_active_participants_constraint` is satisfied, the proposal is authorized.
 
-- banned
-- non-participant
-- guest
-- attendee
-- speaker
-- moderator
-- super_admin
+- `canRemoveSelf` - the holder of this capability can propose to remove itself from (i.e. leave) the participant list; it MUST simultaneously propose to remove all of its remaining clients from the corresponding MLS group.
+  Due to restrictions in MLS which insure the consistency of the group, this action cannot be committed by the leaving user.
+  A proposer holding this capability consults its role's `authorized_role_changes` entries for an entry where `from_role_index` matches its current role; if the `target_role_indexes` for that entry contains zero, and the `minimum_participants_constraint` and `minimum_active_participants_constraint` are satisfied, the proposal is authorized.
 
-Capabilities per role
+- `canKick` - the holder of this capability can propose removal of another participant's clients, without changing the Participant List.
+  If the `minimum_active_participants_constraint` is satisfied, the proposal is authorized.
 
-- banned
-    - (no capabilities)
-- non-participant
-	- canKnock
-	- canJoinViaLink
-- guest
-	- canReceiveMessage
-	- canRemoveSelf
-- attendee
-    - (everything guest can do, plus:)
-	- canAddOwnClient
-	- canChangeOwnName,Presence,Mood,Avatar
-	- canReport
-- speaker
-    - (everything attendee can do, plus:)
-	- canSendMessage
-	- canChangeRoomName,Subject,Avatar
-	- canSendLinks
-    - canSendImages
-    - canSendVideos
-    - canSendAttachments
-- moderator
-	- (everything ordinary_user can do, plus:)
-	- canAddParticipant
-	- canRemoveParticipant
-	- canAcceptKnock
-	- canBan
-	- canUnBan
-	- canKick
-	- canPromoteRole(from=[attendee]; to=[speaker])
-	- canDemoteRole([from=[speaker], to=[attendee])
-	- canCreateJoinLink
-- super_admin
-    - (everything moderator can do, plus:)
-	- canDestroyRoom
-    - canPromoteRole(from=[attendee,speaker], to=[moderator])
-    - canDemoteRole(from=[moderator], to=[attendee,speaker])
-    - canChangeRoomMembershipStyle
 
-Role constraints: must have at least 1 "moderator"
+- `canChangeUserRole` - the holder of this capability is authorized to change the role of another participant (but not itself), according to the holder's `authorized_role_changes` list, from a role represented by an entry where the target's current role matches `from_role_index` to any of the non-zero `target_role_indexes` in the same element of `authorized_role_changes`.
+  The `minimum_participants_constraint` and `minimum_active_participants_constraint` for the target user's current role, and the `maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the target user's target role must also be satisfied.
+
+- `canChangeOwnRole` - the holder of this capability is authorized to change its own role to the first non-zero role it matches in the Preauthorized users component (see {{preauthorized-users}}).
+  The `authorized_role_changes` list is *not* consulted.
+  The `minimum_participants_constraint` and `minimum_active_participants_constraint` for the holder's original role, and the
+`maximum_participants_constraint` (if present) and `maximum_active_participants_constraint` (if present) for the holder's target role must also be satisfied.
+
+- `canBan` - the holder of this capability can propose to "ban" another user.
+  Specifically, a successful ban changes the target user's role to a special "banned" role (if it exists), and removes all the banned user's clients.
+  The "banned" role always has `role_index` = 1 and `role_name` = "banned" (without quotes).
+
+  > A "banned" role does not have to exist in a room, but to use the `canBan` and `canUnban` capabilities, the role needs to exist exactly as described above.
+  > While holding `canChangeUserRole` and `canKick` capabilities would allow the same action, it could potentially allow the holder other actions which might be undesirable in some contexts, such as kicking clients without banning.
+
+  A proposer holding this capability consults its role's `authorized_role_changes` entries for an entry where `from_role_index` matches the target user's current role; if the `target_role_indexes` for that entry contains the `role_index` 1; that `role_name` = "banned" for the role with role_index = 1, and the `minimum_participants_constraint` and `minimum_active_participants_constraint` are satisfied, the proposal is authorized.
+
+- `canUnban` - the holder of this capability can propose to "unban" another user.
+  Specifically, a successful unban changes the target user's role from `role_index` = 1 to another non-zero `role_index` allowed by the holder's `authorized_role_changes` list.
+  Adding clients for that unbanned user is *not* authorized by this capability.
+  The authorization of this capability is identical to the `canChangeUserRole` capability, except that the `from_role_index` for the unbanned user MUST be 1, and the `role_name` of role 1 MUST be "banned".
+
+
+## Adjust metadata
+
+The holder of each of the following capabilities is authorized to update the Room metadata defined in {{!I-D.ietf-mimi-protocol}}, changing the relevant field:
+
+- `canChangeRoomName`
+- `canChangeRoomDescription`
+- `canChangeRoomAvatar`
+- `canChangeRoomSubject`
+- `canChangeRoomMood`
+
+
+## Message Capabilities
+
+The capabilities below refer to functionality related to the instant messages, for example sent using the MIMI content format {{!I-D.ietf-mimi-content}}.
+
+- `canSendMessage` - the holder can send instant messages to the room. Setting specific message fields may require additional capabilities.
+- `canReceiveMessage` - the holder can receive instant messages from the room.
+- `canCopyMessage` - the holder can copy content from a received instant
+message.
+- `canReportAbuse` - the holder can report a franked instant message as abusive.
+- `canReplyToMessage` - the holder can send a message replying to another message.
+- `canReactToMessage` - the holder can send a reaction, replying to another message, and using the "reaction" disposition.
+- `canDeleteOwnReaction` - the holder can retract (unlike) it own previous reaction.
+- `canDeleteOtherReaction` - the holder can delete the reaction of another user's previous reaction
+- `canEditOwnMessage` - the holder can edit the content of one of its own previously sent messages
+- `canDeleteOwnMessage` - the holder can retract one of its own previously sent messages
+- `canDeleteOtherMessage` - the holder can retract messages for other users.
+- `canStartTopic` - the holder can set the topic for a message
+- `canReplyInTopic` - the holder can send a message replying to a previous message, using the same topic as the original sender.
+- `canEditOwnTopic` - the holder can change the topic of a previously sent message
+- `canEditOtherTopic` - the holder can change the topic of a message previously sent by another user.
+- `canSendLink` - the holder can send an inline link
+- `canSendLinkPreview` - the holder can send an inline link with an associated
+preview.
+- `canFollowLink` - the holder can open a sent inline link.
+- `canCopyLink` - the holder can copy the URL of a sent inline link.
+
+The Hub can enforce whether a member can send a message. It can also withhold fanout of application messages to clients of a user. The other capabilities in this section can only be enforced by other clients.
+
+
+## Asset Capabilities
+
+- `canUploadAttachment` - the holder can upload a file with the "attachent" disposition.
+- `canDownloadAttachment` - the holder can download a file with the "attachent" disposition.
+- `canUploadImage` - the holder can upload a file with the media type of "image" and the disposition of "render"
+- `canDownloadImage` - the holder can download a file with the media type of "image" and the disposition of "render"
+- `canUploadVideo` - the holder can upload a file with the media type of "video" and the disposition of "render"
+- `canDownloadVideo` - the holder can download a file with the media type of "video" and the disposition of "render"
+- `canUploadSound` - the holder can upload a file with the media type of "audio" and the disposition of "render"
+- `canDownloadSound` - the holder can download a file with the media type of "audio" and the disposition of "render"
+
+
+## Real-time media
+
+The MIMI Working has not yet defined requirements for real-time media, however the capabilities below are widely representative of the permissions that would be required.
+
+- `canStartCall` - the holder can initiate a new real-time call/conference
+- `canJoinCall` - the holder can join an existing real-time call/conference
+- `canSendAudio` - the holder is authorized to contribute audio in a call/conference.
+- `canReceiveAudio` - the holder is authorized to receive audio in a call/conference.
+- `canSendVideo` - the holder is authorized to contribute video in a call/conference.
+- `canReceiveVideo` - the holder is authorized to receive video in a call/conference.
+- `canShareScreen` - the holder is authorized to contribute screen sharing in a call/conference
+- `canViewSharedScreen` - the holder is authorized to receive screen sharing in a call/conference
+
+## Disruptive Policy Changes
+
+- `canChangeRoomMembershipStyle` - the holder is authorized to modify the base room membership style.
+- `canChangeRoleDefinitions` - the holder is authorized to make changes to the definitions of the Roles component.
+- `canChangePreauthorizedUserList` - the holder is authorized to make changes to the Preauthorized Users component.
+- `canDestroyRoom` - the holder is authorized to completely destroy the room.
+- `canReinitGroup` - the holder is authorized to send an MLS ReInit proposal.
+
+
+## Reserved Capabilities
+
+The following capability names are reserved for possible future use
+
+- `canCreateJoinCode`
+- `canKnock`
+- `canAcceptKnock`
+- `canCreateSubgroup`
+- `canSendDirectMessage`
+- `canTargetMessage`
+- `canChangeOwnName`
+- `canChangeOwnPresence`
+- `canChangeOwnMood`
+- `canChangeOwnAvatar`
+- `canCreateRoom`
+- `canChangeMlsOperationalPolicies`
+- `canChangeOtherPolicyAttribute`
+- MLS specific
+  - update - update policy
+  - PSK - psk policy
+  - external proposal - general operational policy rules
+  - external commit - general operational policy rules
+
+## Extensibility of the policy format
+
+Finally, The extensibility mechanism allows for future addition of new room policies.
+
+~~~
+enum {
+  null(0),
+  boolean(1),
+  number(2),
+  string(3),
+  jsonObject(4)
+} ExtType;
+
+struct {
+  opaque name<V>;
+  ExtType type;
+  opaque value<V>;
+} PolicyExtension;
+
+struct {
+  ...
+  PolicyExtension policy_extensions<V>;
+} RoomPolicy;
+~~~
+
 
 
 # Security Considerations
@@ -720,6 +713,599 @@ This document has no IANA actions.
 
 
 --- back
+
+# Role examples
+
+## Cooperatively administered room
+
+This is an example set of role policies, which is suitable for friends and family rooms and small groups of peers in a workgroup or club.
+
+- no_role
+   - role_index = 0
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- banned
+   - role_index = 1
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- ordinary_user
+   - role_index = 2
+   - authorized capabilities
+      - canAddParticipant
+      - canRemoveParticipant
+      - canAddOwnClient
+      - canRemoveOwnClient
+      - canRemoveSelf
+      - canSendMessage
+      - canReceiveMessage
+      - canCopyMessage
+      - canReportAbuse
+      - canReplyToMessage
+      - canReactToMessage
+      - canDeleteOwnReaction
+      - canEditOwnMessage
+      - canDeleteOwnMessage
+      - canStartTopic
+      - canReplyInTopic
+      - canEditOwnTopic
+      - canUploadImage
+      - canUploadVideo
+      - canUploadSound
+      - canUploadAttachment
+      - canDownloadImage
+      - canDownloadVideo
+      - canDownloadSound
+      - canDownloadAttachment
+      - canSendLink
+      - canSendLinkPreview
+      - canFollowLink
+      - canCopyLink
+      - canChangeRoomName
+      - canChangeRoomAvatar
+      - canChangeRoomSubject
+      - canChangeRoomMood
+      - canChangeOwnName
+      - canChangeOwnPresence
+      - canChangeOwnMood
+      - canChangeOwnAvatar
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2]), (2,[0])]`
+
+- group_admin
+   - role_index = 3
+   - authorized capabilities
+      - (include all the capabilities authorized for an ordinary_user)
+      - canBan
+      - canUnBan
+      - canKick
+      - canRevokeVoice
+      - canGrantVoice
+      - canChangeUserRole
+      - canDeleteOtherMessage
+      - canEditOtherTopic
+      - canChangeRoomDescription
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3]), (1,[0,2,3]), (2,[0,1,3]), (3,[0,1,2])]`
+
+- super_admin
+   - role_index = 4
+   - authorized capabilities
+      - (include all the capabilities authorized for a group_admin)
+      - canChangeRoomMembershipStyle
+      - canChangePreauthorizedUserList
+      - canDestroyRoom
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3,4]), (1,[0,2,3,4]), (2,[0,1,3,4]), (3,[0,1,2,4]), (4,[0,1,2,3])]`
+
+
+- policy_enforcer
+   - role_index = 5
+   - capabilities
+      - (does not include any other capabilities)
+      - canRemoveParticipant
+      - canChangeUserRole
+      - canBan
+      - canUnban
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canChangeMlsOperationalPolicies
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 2
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[(0,[1]), (1,[0]), (2,[0,1]), (3,[0,1]), (4,[0,1])]`
+   - Notes: can remove a banned user from the list (cleanup) but not restore them
+
+
+
+## Strictly administered room
+
+This is an example set of role policies, which is suitable for friends and family rooms and small groups of peers in a workgroup or club.
+
+- no_role
+   - role_index = 0
+   - authorized capabilities
+      - canUseJoinCode
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[(0,[2])]`
+
+- banned
+   - role_index = 1
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- ordinary_user
+   - role_index = 2
+   - authorized capabilities
+      - canAddOwnClient
+      - canAddSelf
+      - canRemoveOwnClient
+      - canRemoveSelf
+      - canChangeOwnRole
+      - canSendMessage
+      - canReceiveMessage
+      - canCopyMessage
+      - canReportAbuse
+      - canReactToMessage
+      - canDeleteOwnReaction
+      - canEditOwnMessage
+      - canDeleteOwnMessage
+      - canStartTopic
+      - canReplyInTopic
+      - canUploadImage
+      - canUploadVideo
+      - canUploadSound
+      - canUploadAttachment
+      - canDownloadImage
+      - canDownloadVideo
+      - canDownloadSound
+      - canDownloadAttachment
+      - canSendLink
+      - canSendLinkPreview
+      - canFollowLink
+      - canCopyLink
+      - canChangeOwnName
+      - canChangeOwnPresence
+      - canChangeOwnMood
+      - canChangeOwnAvatar
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2]), (2,[0])]`
+
+- group_admin
+   - role_index = 3
+   - authorized capabilities
+      - (include all the capabilities authorized for an ordinary_user)
+      - canAddParticipant
+      - canRemoveParticipant
+      - canBan
+      - canUnBan
+      - canKick
+      - canChangeUserRole
+      - canCreateJoinCode - reserved for future use
+      - canDeleteOtherReaction
+      - canDeleteOtherMessage
+      - canEditOwnTopic
+      - canEditOtherTopic
+      - canChangeRoomDescription
+      - canChangeRoomName
+      - canChangeRoomAvatar
+      - canChangeRoomSubject
+      - canChangeRoomMood
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3]), (1,[0,2,3]), (2,[0,1,3]), (3,[0,1,2])]`
+
+- super_admin
+   - role_index = 4
+   - authorized capabilities
+      - (include all the capabilities authorized for a group_admin)
+      - canChangeRoomMembershipStyle
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3,4]), (1,[0,2,3,4]), (2,[0,1,3,4]), (3,[0,1,2,4]), (4,[0,1,2,3])]`
+
+
+- policy_enforcer
+   - role_index = 5
+   - capabilities
+      - (does not include any other capabilities)
+      - canRemoveParticipant
+      - canChangeUserRole
+      - canBan
+      - canUnban
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canChangeMlsOperationalPolicies
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 2
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[(0,[1]), (1,[0]), (2,[0,1]), (3,[0,1]), (4,[0,1])]`
+   - Notes: can remove a banned user from the list (cleanup) but not restore them
+
+
+## Moderated room
+
+- no_role
+   - role_index = 0
+   - authorized capabilities
+      - canUseJoinCode
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2,3])]`
+
+- banned
+   - role_index = 1
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- guest
+   - role_index = 2
+   - authorized capabilities
+      - canRemoveSelf
+      - canReceiveMessage
+      - canCopyMessage
+      - canReactToMessage
+      - canDeleteOwnReaction
+      - canFollowLink
+      - canCopyLink
+      - canDownloadImage
+      - canDownloadVideo
+      - canDownloadSound
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2]), (2,[0])]`
+
+- attendee
+   - role_index = 3
+   - authorized capabilities
+      - (include all the capabilities authorized for a guest)
+      - canAddOwnClient
+      - canAddSelf
+      - canRemoveOwnClient
+      - canChangeOwnRole
+      - canReportAbuse
+      - canReplyInTopic
+      - canDownloadAttachment
+      - canChangeOwnName
+      - canChangeOwnPresence
+      - canChangeOwnAvatar
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[3]), (3,[0])]`
+
+- speaker
+   - role_index = 4
+   - authorized capabilities
+      - (include all the capabilities authorized for a speaker)
+      - canSendMessage
+      - canEditOwnMessage
+      - canDeleteOwnMessage
+      - canStartTopic
+      - canUploadImage
+      - canUploadVideo
+      - canUploadSound
+      - canUploadAttachment
+      - canSendLink
+      - canSendLinkPreview
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[4]), (4,[0])]`
+
+- moderator
+   - role_index = 5
+   - authorized capabilities
+      - (include all the capabilities authorized for an ordinary_user)
+      - canAddParticipant
+      - canRemoveParticipant
+      - canBan
+      - canUnBan
+      - canKick
+      - canChangeUserRole
+      - canCreateJoinCode - reserved for future use
+      - canDeleteOtherReaction
+      - canDeleteOtherMessage
+      - canEditOwnTopic
+      - canEditOtherTopic
+      - canChangeRoomName
+      - canChangeRoomAvatar
+      - canChangeRoomSubject
+      - canChangeRoomMood
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3,4,5]), (1,[0,2,3,4,5]), (2,[0,1,3,4,5]), (3,[0,1,2,4,5]), (4,[0,1,2,3,5]), (5,[0,1,2,3,4])]`
+
+- super_admin
+   - role_index = 6
+   - authorized capabilities
+      - (include all the capabilities authorized for a moderator)
+      - canChangeRoomDescription
+      - canChangeRoomMembershipStyle
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3,4,5,6]), (1,[0,2,3,4,5,6]), (2,[0,1,3,4,5,6]), (3,[0,1,2,4,5,6]), (4,[0,1,2,3,5,6]), (5,[0,1,2,3,4,6]), (6,[0,1,2,3,4,5])]`
+
+
+- policy_enforcer
+   - role_index = 7
+   - capabilities
+      - (does not include any other capabilities)
+      - canRemoveParticipant
+      - canChangeUserRole
+      - canBan
+      - canUnban
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canChangeMlsOperationalPolicies
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 2
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[(0,[1]), (1,[0]), (2,[0,1]), (3,[0,1]), (4,[0,1]), (5, [0,1]), (6, [0,1])]`
+   - Notes: can remove a banned user from the list (cleanup) but not restore them
+
+
+
+## Multi-organization administered room
+
+In this example room policy, Alice from organization A is a super admin.
+There are per organization user and admin roles for orgs A, B, and C.
+Organizational admins can only move users to and from their org user role, their org admin role, the no_role; and can ban (but not unban) their own org users.
+The non-host orgs do not have the `canChangeOwnRole` and `canAddSelf`, and are limited to 3 admins per org.
+
+- no_role
+   - role_index = 0
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- banned
+   - role_index = 1
+   - no capabilities
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[]`
+
+- org_a_user
+   - role_index = 2
+   - authorized capabilities
+      - (all capabilities of org_b_user)
+      - canChangeOwnRole
+      - canAddSelf
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2]), (2,[0])]`
+
+- org_b_user
+   - role_index = 3
+   - authorized capabilities
+      - canRemoveSelf
+      - canAddOwnClient
+      - canRemoveOwnClient
+      - canSendMessage
+      - canReceiveMessage
+      - canCopyMessage
+      - canReportAbuse
+      - canReplyInTopic
+      - canReactToMessage
+      - canDeleteOwnReaction
+      - canEditOwnMessage
+      - canSendLink
+      - canSendLinkPreview
+      - canFollowLink
+      - canCopyLink
+      - canDownloadImage
+      - canDownloadVideo
+      - canDownloadSound
+      - canDownloadAttachment
+      - canChangeOwnName
+      - canChangeOwnPresence
+      - canChangeOwnAvatar
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[3]), (3,[0])]`
+
+- org_c_user
+   - role_index = 4
+   - authorized capabilities
+      - (same capabilities as org_b_user)
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[4]), (4,[0])]`
+
+- org_a_admin
+   - role_index = 5
+   - authorized capabilities
+      - (all capabilities of org_b_admin)
+      - canChangeOwnRole
+      - canAddSelf
+   - constraints
+      - minimum_participants_constraint = 0
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[2,5]), (2,[0,1,5]), (5,[0,1,2])]`
+
+- org_b_admin
+   - role_index = 6
+   - authorized capabilities
+      - (all capabilities of org_b_user)
+      - canDeleteOwnMessage
+      - canStartTopic
+      - canUploadImage
+      - canUploadVideo
+      - canUploadSound
+      - canUploadAttachment
+      - canAddParticipant
+      - canRemoveParticipant
+      - canBan
+      - canKick
+      - canChangeUserRole
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 3
+      - minimum_active_participants_constraint = 1
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[3,6]), (3,[0,1,6]), (6,[0,1,3])]`
+
+- org_c_admin
+   - role_index = 7
+   - authorized capabilities
+      - (all capabilities of org_b_admin)
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 3
+      - minimum_active_participants_constraint = 1
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[4,7]), (4,[0,1,7]), (7,[0,1,4])]`
+
+- super_admin
+   - role_index = 8
+   - authorized capabilities
+      - (include all the capabilities authorized for org_a_admin)
+      - canUnBan
+      - canDeleteOtherReaction
+      - canDeleteOtherMessage
+      - canEditOwnTopic
+      - canEditOtherTopic
+      - canChangeRoomDescription
+      - canChangeRoomName
+      - canChangeRoomAvatar
+      - canChangeRoomSubject
+      - canChangeRoomMood
+      - canChangeRoomMembershipStyle
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = null
+      - minimum_active_participants_constraint = 1
+      - maximum_active_participants_constraint = null
+      - authorized_role_changes = `[(0,[1,2,3,4,5,6,7,8]), (1,[0,2,3,4,5,6,7,8]), (2,[0,1,5,8]), (3,[0,1,6]), (4,[0,1,7]), (5,[0,1,2,8]), (6,[0,1,3]), (7,[0,1,4]), (8,[0,1,2,5])]`
+
+- policy_enforcer
+   - role_index = 9
+   - capabilities
+      - (does not include any other capabilities)
+      - canRemoveParticipant
+      - canChangeUserRole
+      - canBan
+      - canUnban
+      - canChangeRoleDefinitions
+      - canChangePreauthorizedUserList
+      - canChangeMlsOperationalPolicies
+      - canDestroyRoom
+      - canSendMLSReinitProposal
+   - constraints
+      - minimum_participants_constraint = 1
+      - maximum_participants_constraint = 2
+      - minimum_active_participants_constraint = 0
+      - maximum_active_participants_constraint = 0
+      - authorized_role_changes = `[(0,[1]), (1,[0]), (3,[0,1]), (4,[0,1]), (5,[0,1]), (6,[0,1]), (7,[0,1]), (8,[0,1])]`
+   - Notes: can remove a banned user from the list (cleanup) but not restore them
+
+
 
 # Complete TLS Presentation Language Syntax
 


### PR DESCRIPTION
Removed RBAC and Preauth and replaced with content from app-components
Added copious examples
Removed policies that are no longer needed with a powerful RBAC system.