### PR TITLE
write LinkPreviewPolicy; finish to AssetPolicy, add local client bots in BotPolicy

### DIFF
--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -557,9 +557,10 @@ There are several types of chat bot in instant messaging systems, some of which 
 Inside the BotPolicy there is a list of `allowed_bots`, each of which has several fields.
 The `name`, `description`, and `homepage` are merely descriptive.
 
-If `local_client_bot` is true, the bot would not act as a participant; it would have access to the contents of room only with another client operated by a (presumably human) user.
+If `local_client_bot` is true, the bot would not act as a participant; it would have access to the contents of the room only with another client operated by a (presumably human) user.
 
 The `bot_role_index` indicates the role index in which the bot operates; this controls the capabilities of the bot.
+A `bot_role_index` of zero indicates that the bot is not a active participant in the room.
 A bot with `local_client_bot` set to true has a `bot_role_index` of 0.
 
 If `can_target_message_in_group` is true it indicates that the chat bot can send an MLS targeted message (see Section 2.2 of [I-D.ietf-mls-extensions]) or use a different conversation or out-of-band channel to send a message to specific individual users in the room.

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -1703,6 +1703,12 @@ struct {
   opaque uri<V>;
 } Uri;
 
+enum {
+  optional(0),
+  required(1),
+  forbidden(2)
+} Optionality;
+
 
 /* See MIMI Capability Types IANA registry */
 uint16 CapabilityType;
@@ -1728,6 +1734,7 @@ struct {
   Role roles<V>;
 } RoleData;
 
+RoleData roles_list;
 RoleData RoleUpdate;
 
 
@@ -1755,14 +1762,26 @@ struct {
   PreAuthRoleEntry preauthorized_entries<V>;
 } PreAuthData;
 
+PreAuthData preauth_list;
 PreAuthData PreAuthUpdate;
 
 
-enum {
-  optional(0),
-  required(1),
-  forbidden(2)
-} Optionality;
+struct {
+    bool fixed_membership;
+    bool parent_dependant;
+    Uri parent_room<V>;
+    bool multi_device;
+    optional uint32 max_clients;
+    optional uint32 max_users;
+    bool pseudonyms_allowed;
+    bool persistent_room;
+    bool discoverable;
+    Component policy_components<V>;
+} BaseRoomPolicy;
+
+BaseRoomPolicy BaseRoomData;
+BaseRoomPolicy BaseRoomUpdate;
+
 
 struct {
   Optionality delivery_notifications;
@@ -1963,23 +1982,6 @@ struct {
 
 OperationalParameters OperationalParametersData;
 OperationalParameters OperationalParametersUpdate;
-
-
-struct {
-    bool fixed_membership;
-    bool parent_dependant;
-    Uri parent_room<V>;
-    bool multi_device;
-    optional uint32 max_clients;
-    optional uint32 max_users;
-    bool pseudonyms_allowed;
-    bool persistent_room;
-    bool discoverable;
-    Component policy_components<V>;
-} BaseRoomPolicy;
-
-BaseRoomPolicy BaseRoomData;
-BaseRoomPolicy BaseRoomUpdate;
 ~~~
 
 

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -449,6 +449,8 @@ struct {
   opaque media_type<V>;
 } MediaType;
 
+
+
 struct {
   AssetUploadLocation asset_upload_location;
   ProviderAssetUploadDomains upload_domains<V>;
@@ -468,11 +470,11 @@ AssetPolicy AssetPolicyUpdate;
 The `max_image`, `max_audio`, `max_video`, and `max_attachment` fields indication the maximum size in bytes  of the corresponding assets that will be accepted.
 These amounts could be further limited at the client according to local policy or at the upload location based on various forms of authorization and quotas.
 
-`forbidden_media_types` is a list of media types that are not allowed at all in the room.
+The following paragraph refers to fields that use the `MediaType` struct defined in {{Section 6.2.2 of !I-D.ietf-mls-extensions}}.
+`forbidden_media_types` is a list of media types (type and subtype) that are not allowed at all in the room.
 If present, `permitted_media_types` is a list of media types that are permitted.
 When it is present, media types MUST be one of the entries in the `permitted_media_types` list, and MUST NOT be in the `forbidden_media_types` list.
-If a media type without a subtype (for example, `audio`) is present in one of these lists, it matches all media types of any subtype with that type.
-If a media type without parameters (for example, `text/markdown`) is present in one of these lists, it matches all media types of that type and subtype regardless of additional parameters.
+If a media type with no parameters (for example, `text/markdown`) is present in one of these lists, that entry matches all media types of that type and subtype that contain additional parameters.
 
 
 ## Logging policy component {#logging}

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -159,6 +159,7 @@ struct {
   Role roles<V>;
 } RoleData;
 
+RoleData roles_list;
 RoleData RoleUpdate;
 ~~~
 
@@ -210,6 +211,7 @@ struct {
   PreAuthRoleEntry preauthorized_entries<V>;
 } PreAuthData;
 
+PreAuthData preauth_list;
 PreAuthData PreAuthUpdate;
 ~~~
 
@@ -312,7 +314,7 @@ If `persistent_room` is true, the room policy will remain and a client whose use
 If `discoverable` is true, the room is searchable in some way.
 Presumably this means that if `discoverable` is false, the only way to join the room in a client user interface is to be added by an administrator or to use a joining link.
 
-Finally, the other policy components that are relevant to this room are listed in the `policy_components` vector, including the `roles_list` and `preauth_list` components (if present).
+Finally, the other policy components that are relevant to this room are listed in the `policy_components` vector, including the `roles_list` (from {{roles}}) and `preauth_list` components (from {{preauth}}), if present.
 This extensibility mechanism allows for future addition or replacement of new room policies.
 
 
@@ -910,10 +912,10 @@ This document registers the following MLS Component Types per {{Section 7.5 of !
 - Recommended: Y
 - Reference: {{operational}} of RFCXXXX
 
-### role_list MLS Component Type
+### roles_list MLS Component Type
 
 - Value: TBD1
-- Name: role_list
+- Name: roles_list
 - Where: GC
 - Recommended: Y
 - Reference: {{roles}} of RFCXXXX

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -861,6 +861,7 @@ The MIMI Working has not yet defined requirements for real-time media, however t
 The following capability names are reserved for possible future use
 
 - `canCreateJoinCode`
+- `canDeleteJoinCode`
 - `canKnock`
 - `canAcceptKnock`
 - `canCreateSubgroup`
@@ -1011,15 +1012,16 @@ Template:
 | 0x0004 | canAddSelf                                 | RFCXXXX   |
 | 0x0005 | canRemoveSelf                              | RFCXXXX   |
 | 0x0006 | canCreateJoinCode (reserved)               | RFCXXXX   |
-| 0x0007 | canUseJoinCode                             | RFCXXXX   |
-| 0x0008 | canBan                                     | RFCXXXX   |
-| 0x0009 | canUnBan                                   | RFCXXXX   |
-| 0x000a | canKick                                    | RFCXXXX   |
-| 0x000b | canKnock (reserved)                        | RFCXXXX   |
-| 0x000c | canAcceptKnock (reserved)                  | RFCXXXX   |
-| 0x000d | canChangeUserRole                          | RFCXXXX   |
-| 0x000e | canChangeOwnRole                           | RFCXXXX   |
-| 0x000f | canCreateSubgroup (reserved)               | RFCXXXX   |
+| 0x0007 | canDeleteJoinCode (reserved)               | RFCXXXX   |
+| 0x0008 | canUseJoinCode                             | RFCXXXX   |
+| 0x0009 | canBan                                     | RFCXXXX   |
+| 0x000a | canUnBan                                   | RFCXXXX   |
+| 0x000b | canKick                                    | RFCXXXX   |
+| 0x000c | canKnock (reserved)                        | RFCXXXX   |
+| 0x000d | canAcceptKnock (reserved)                  | RFCXXXX   |
+| 0x000e | canChangeUserRole                          | RFCXXXX   |
+| 0x000f | canChangeOwnRole                           | RFCXXXX   |
+| 0x0010 | canCreateSubgroup (reserved)               | RFCXXXX   |
 | 0x0100 | canSendMessage                             | RFCXXXX   |
 | 0x0101 | canReceiveMessage                          | RFCXXXX   |
 | 0x0102 | canCopyMessage                             | RFCXXXX   |
@@ -1036,7 +1038,7 @@ Template:
 | 0x010d | canReplyInTopic                            | RFCXXXX   |
 | 0x010e | canEditOwnTopic                            | RFCXXXX   |
 | 0x010f | canEditOtherTopic                          | RFCXXXX   |
-| 0x0111 | canSendDirectMessage (reserved)            | RFCXXXX   |
+| 0x0110 | canSendDirectMessage (reserved)            | RFCXXXX   |
 | 0x0111 | canTargetMessage (reserved)                | RFCXXXX   |
 | 0x0200 | canUploadImage                             | RFCXXXX   |
 | 0x0201 | canUploadAudio                             | RFCXXXX   |
@@ -1290,6 +1292,7 @@ This is an example set of role policies, which is suitable for friends and famil
       - canKick
       - canChangeUserRole
       - canCreateJoinCode - reserved for future use
+      - canDeleteJoinCode - reserved for future use
       - canDeleteOtherReaction
       - canDeleteOtherMessage
       - canEditOwnTopic
@@ -1441,6 +1444,7 @@ This is an example set of role policies, which is suitable for friends and famil
       - canKick
       - canChangeUserRole
       - canCreateJoinCode - reserved for future use
+      - canDeleteJoinCode - reserved for future use
       - canDeleteOtherReaction
       - canDeleteOtherMessage
       - canEditOwnTopic

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -376,23 +376,31 @@ JoinLinkPolicy JoinLinkPolicyUpdate;
 ## Link Preview policy component {#link-preview}
 
 Link preview policy is concerned with the safe rendering of explicit or implicit hyperlinks in the text of an instant message.
-The `send_link_previews` setting indicates if the receiver of a message generating link previews (a desirable feature, but a potential privacy concern) is mandatory, optional, or forbidden.
-
-The `link_preview_proxy_use` setting indicates if using a specialized link preview proxy is mandatory, optional, or forbidden when link previews are generated.
-Its value MUST be `forbidden` if `send_link_previews` is `forbidden`.
-
-The `link_preview_proxy` setting MUST include the URI of a link preview proxy if `link_preview_proxy_uses` is `mandatory` or `optional`.
 
 The `autodetect_hyperlinks_in_text` setting indicates if a message composer is expected to detect hyperlinks from text which resembles links (ex: `http://example.com`).
 The value of `autodetect_hyperlinks_in_text` MUST NOT be `mandatory`.
+The `send_link_previews` setting indicates if the sender of a message including a link preview (a desirable feature, but a malicious sender could generate a preview inconsistent with the actual link content) is mandatory, optional, or forbidden.
+
+The `automatic_link_previews` setting indicates if the receiver of a message generating link previews (a desirable feature, but a potential privacy concern) is mandatory, optional, or forbidden.
+The `link_preview_proxy_use` setting indicates if using a specialized link preview proxy is mandatory, optional, or forbidden when link previews are generated.
+
+The `link_preview_proxy` setting MUST include the URI of a link preview proxy if `link_preview_proxy_use` is `mandatory` or `optional`.
+
 
 ~~~ tls
 struct {
+  Optionality autodetect_hyperlinks_in_text;
   Optionality send_link_previews;
   Optionality automatic_link_previews;
   Optionality link_preview_proxy_use;
-  Uri link_preview_proxy<V>;
-  Optionality autodetect_hyperlinks_in_text;
+  select (link_preview_proxy_use) {
+    case mandatory:
+      Uri link_preview_proxy<V>;
+    case optional:
+      Uri link_preview_proxy<V>;
+    case forbidden:
+      struct {}
+  }
 } LinkPreviewPolicy;
 
 LinkPreviewPolicy LinkPreviewPolicyData;

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -542,6 +542,7 @@ The `name`, `description`, and `homepage` are merely descriptive.
 If `local_client_bot` is true, the bot would not act as a participant; it would have access to the contents of room only with another client operated by a (presumably human) user.
 
 The `bot_role_index` indicates the role index in which the bot operates; this controls the capabilities of the bot.
+A bot with `local_client_bot` set to true has a `bot_role_index` of 0.
 
 If `can_target_message_in_group` is true it indicates that the chat bot can send an MLS targeted message (see Section 2.2 of [I-D.ietf-mls-extensions]) or use a different conversation or out-of-band channel to send a message to specific individual users in the room.
 
@@ -655,24 +656,24 @@ struct {
 
 enum {
   unspecified(0),
-  immediateCommit(1),
-  randomDelay(2),
-  preferenceWheel(3),
-  designatedCommitter(4),
-  treeProximity(5)
+  immediate_commit(1),
+  random_delay(2),
+  preference_wheel(3),
+  designated_committer(4),
+  tree_proximity(5)
   (255)
 } PendingProposalStrategy;
 
 struct {
   PendingProposalStrategy pending_proposal_strategy;
-  uint64 minimumDelayMs;
-  uint64 maximumDelayMs;
+  uint64 minimum_delay_ms;
+  uint64 maximum_delay_ms;
 } PendingProposalPolicy;
 
 struct {
-  uint64 minimumTime;
-  uint64 defaultTime;
-  uint64 maximumTime;
+  uint64 minimum_time;
+  uint64 default_time;
+  uint64 maximum_time;
 } MinDefaultMaxTime;
 
 
@@ -1785,10 +1786,18 @@ JoinLinkPolicy JoinLinkPolicyUpdate;
 
 
 struct {
+  Optionality autodetect_hyperlinks_in_text;
+  Optionality send_link_previews;
   Optionality automatic_link_previews;
   Optionality link_preview_proxy_use;
-  Uri link_preview_proxy<V>;
-  Optionality autodetect_hyperlinks_in_text;
+  select (link_preview_proxy_use) {
+    case mandatory:
+      Uri link_preview_proxy<V>;
+    case optional:
+      Uri link_preview_proxy<V>;
+    case forbidden:
+      struct {}
+  }
 } LinkPreviewPolicy;
 
 LinkPreviewPolicy LinkPreviewPolicyData;

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -374,10 +374,10 @@ JoinLinkPolicy JoinLinkPolicyUpdate;
 ## Link Preview policy component {#link-preview}
 
 Link preview policy is concerned with the safe rendering of explicit or implicit hyperlinks in the text of an instant message.
-The `automatic_link_previews` setting indicates if the receiver of a message generating link previews (a desirable feature, but a potential privacy concern) is mandatory, optional, or forbidden.
+The `send_link_previews` setting indicates if the receiver of a message generating link previews (a desirable feature, but a potential privacy concern) is mandatory, optional, or forbidden.
 
 The `link_preview_proxy_use` setting indicates if using a specialized link preview proxy is mandatory, optional, or forbidden when link previews are generated.
-Its value MUST be `forbidden` if `automatic_link_previews` is `fobidden`.
+Its value MUST be `forbidden` if `send_link_previews` is `forbidden`.
 
 The `link_preview_proxy` setting MUST include the URI of a link preview proxy if `link_preview_proxy_uses` is `mandatory` or `optional`.
 
@@ -386,6 +386,7 @@ The value of `autodetect_hyperlinks_in_text` MUST NOT be `mandatory`.
 
 ~~~ tls
 struct {
+  Optionality send_link_previews;
   Optionality automatic_link_previews;
   Optionality link_preview_proxy_use;
   Uri link_preview_proxy<V>;
@@ -456,14 +457,14 @@ struct {
   uint64 max_video;
   uint64 max_attachment;
   MediaType forbidden_media_types<V>;
-  optional MediaType permitted_media_types<V>;
+  optional<MediaType> permitted_media_types<V>;
 } AssetPolicy;
 
 AssetPolicy AssetPolicyData;
 AssetPolicy AssetPolicyUpdate;
 ~~~
 
-The `max_image`, `max_audio`, `max_video`, and `max_attachment` fields indication the maximum size in bytes  of the corresponding assets that will be accepted.
+The `max_image`, `max_audio`, `max_video`, and `max_attachment` fields indication the maximum size in bytes of the corresponding assets that will be accepted.
 These amounts could be further limited at the client according to local policy or at the upload location based on various forms of authorization and quotas.
 
 The following paragraph refers to fields that use the `MediaType` struct defined in {{Section 6.2.2 of !I-D.ietf-mls-extensions}}.

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -399,7 +399,7 @@ struct {
     case optional:
       Uri link_preview_proxy<V>;
     case forbidden:
-      struct {}
+      struct {};
   }
 } LinkPreviewPolicy;
 
@@ -499,9 +499,18 @@ If logging is optional and there is at least one `logging_client` then logging i
 ~~~ tls
 struct {
   Optionality logging;
-  Uri logging_clients<V>;
-  Uri machine_readable_policy;
-  Uri human_readable_policy;
+  select (logging) {
+    case mandatory:
+      Uri logging_clients<V>;
+      Uri machine_readable_policy;
+      Uri human_readable_policy;
+    case optional:
+      Uri logging_clients<V>;
+      Uri machine_readable_policy;
+      Uri human_readable_policy;
+    case forbidden:
+      struct {};
+  }
 } LoggingPolicy;
 
 LoggingPolicy LoggingPolicyData;
@@ -522,9 +531,18 @@ The history that is shared is limited to `max_time_period` seconds worth of hist
 ~~~ tls
 struct {
   Optionality history_sharing;
-  uint32 roles_that_can_share<V>;
-  bool automatically_share;
-  uint32 max_time_period;
+  select (history_sharing) {
+    case mandatory:
+      uint32 roles_that_can_share<V>;
+      bool automatically_share;
+      uint32 max_time_period;
+    case optional:
+      uint32 roles_that_can_share<V>;
+      bool automatically_share;
+      uint32 max_time_period;
+    case forbidden:
+      struct {};
+  }
 } HistoryPolicy;
 
 HistoryPolicy HistoryPolicyData;
@@ -586,9 +604,18 @@ When `expiring_messages` is forbidden, both the `min_expiration_duration` and th
 ~~~ tls
 struct {
   Optionality expiring_messages;
-  uint32 min_expiration_duration;
-  uint32 max_expiration_duration;
-  optional uint32 default_expiration_duration;
+  select (expiring_messages) {
+    case mandatory:
+      uint32 min_expiration_duration;
+      uint32 max_expiration_duration;
+      optional uint32 default_expiration_duration;
+    case optional:
+      uint32 min_expiration_duration;
+      uint32 max_expiration_duration;
+      optional uint32 default_expiration_duration;
+    case forbidden:
+      struct {};
+  }
 } MessageExpiration;
 
 MessageExpiration MessageExpirationData;
@@ -1703,6 +1730,10 @@ struct {
   opaque uri<V>;
 } Uri;
 
+struct {
+  opaque domain<V>;
+} DomainName;
+
 enum {
   optional(0),
   required(1),
@@ -1815,7 +1846,7 @@ struct {
     case optional:
       Uri link_preview_proxy<V>;
     case forbidden:
-      struct {}
+      struct {};
   }
 } LinkPreviewPolicy;
 
@@ -1829,10 +1860,6 @@ enum {
   hub(2),
   (255)
 } AssetUploadLocation;
-
-struct {
-  opaque domain<V>;
-} DomainName;
 
 struct {
   DomainName provider;
@@ -1861,7 +1888,7 @@ struct {
   uint64 max_video;
   uint64 max_attachment;
   MediaType forbidden_media_types<V>;
-  optional MediaType permitted_media_types<V>;
+  optional<MediaType> permitted_media_types<V>;
 } AssetPolicy;
 
 AssetPolicy AssetPolicyData;
@@ -1870,9 +1897,18 @@ AssetPolicy AssetPolicyUpdate;
 
 struct {
   Optionality logging;
-  Uri logging_clients<V>;
-  Uri machine_readable_policy;
-  Uri human_readable_policy;
+  select (logging) {
+    case mandatory:
+      Uri logging_clients<V>;
+      Uri machine_readable_policy;
+      Uri human_readable_policy;
+    case optional:
+      Uri logging_clients<V>;
+      Uri machine_readable_policy;
+      Uri human_readable_policy;
+    case forbidden:
+      struct {};
+  }
 } LoggingPolicy;
 
 LoggingPolicy LoggingPolicyData;
@@ -1881,9 +1917,18 @@ LoggingPolicy LoggingPolicyUpdate;
 
 struct {
   Optionality history_sharing;
-  uint32 roles_that_can_share<V>;
-  bool automatically_share;
-  uint32 max_time_period;
+  select (history_sharing) {
+    case mandatory:
+      uint32 roles_that_can_share<V>;
+      bool automatically_share;
+      uint32 max_time_period;
+    case optional:
+      uint32 roles_that_can_share<V>;
+      bool automatically_share;
+      uint32 max_time_period;
+    case forbidden:
+      struct {};
+  }
 } HistoryPolicy;
 
 HistoryPolicy HistoryPolicyData;
@@ -1910,9 +1955,18 @@ BotPolicy BotPolicyUpdate;
 
 struct {
   Optionality expiring_messages;
-  uint32 min_expiration_duration;
-  uint32 max_expiration_duration;
-  optional uint32 default_expiration_duration;
+  select (expiring_messages) {
+    case mandatory:
+      uint32 min_expiration_duration;
+      uint32 max_expiration_duration;
+      optional uint32 default_expiration_duration;
+    case optional:
+      uint32 min_expiration_duration;
+      uint32 max_expiration_duration;
+      optional uint32 default_expiration_duration;
+    case forbidden:
+      struct {};
+  }
 } MessageExpiration;
 
 MessageExpiration MessageExpirationData;
@@ -1934,26 +1988,25 @@ struct {
 
 enum {
   unspecified(0),
-  immediateCommit(1),
-  randomDelay(2),
-  preferenceWheel(3),
-  designatedCommitter(4),
-  treeProximity(5)
+  immediate_commit(1),
+  random_delay(2),
+  preference_wheel(3),
+  designated_committer(4),
+  tree_proximity(5)
   (255)
 } PendingProposalStrategy;
 
 struct {
   PendingProposalStrategy pending_proposal_strategy;
-  uint64 minimumDelayMs;
-  uint64 maximumDelayMs;
+  uint64 minimum_delay_ms;
+  uint64 maximum_delay_ms;
 } PendingProposalPolicy;
 
 struct {
-  uint64 minimumTime;
-  uint64 defaultTime;
-  uint64 maximumTime;
+  uint64 minimum_time;
+  uint64 default_time;
+  uint64 maximum_time;
 } MinDefaultMaxTime;
-
 
 struct {
   uint8  epoch_tolerance;


### PR DESCRIPTION
- add LinkPreviewPolicy struct and descriptions for the whole policy.
- add domain checks and allowed media types to AssetPolicy, and descriptions for all of AssetPolicy
- add `local_client_bot` option in `Bot`
- remove section 9 on Extensibility of format since that's baked into the refactor of BasePolicy
- rewrite Appendix B (combined TLS presentation language)

addresses #8 