### PR TITLE
Cleanup three policy structs

### DIFF
--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -298,7 +298,7 @@ struct {
     bool pseudonyms_allowed;
     bool persistent_room;
     bool discoverable;
-    Component policy_components<V>;
+    Component policy_component_ids<V>;
 } BaseRoomPolicy;
 
 BaseRoomPolicy BaseRoomData;
@@ -314,7 +314,7 @@ If `persistent_room` is true, the room policy will remain and a client whose use
 If `discoverable` is true, the room is searchable in some way.
 Presumably this means that if `discoverable` is false, the only way to join the room in a client user interface is to be added by an administrator or to use a joining link.
 
-Finally, the other policy components that are relevant to this room are listed in the `policy_components` vector, including the `roles_list` (from {{roles}}) and `preauth_list` components (from {{preauth}}), if present.
+Finally, the Component IDs of the other policy components that are relevant to this room are listed in the `policy_component_ids` vector, including the `roles_list` (from {{roles}}) and `preauth_list` components (from {{preauth}}), if present.
 This extensibility mechanism allows for future addition or replacement of new room policies.
 
 
@@ -1840,7 +1840,7 @@ struct {
     bool pseudonyms_allowed;
     bool persistent_room;
     bool discoverable;
-    Component policy_components<V>;
+    Component policy_component_ids<V>;
 } BaseRoomPolicy;
 
 BaseRoomPolicy BaseRoomData;

--- a/draft-ietf-mimi-room-policy.md
+++ b/draft-ietf-mimi-room-policy.md
@@ -686,16 +686,22 @@ enum {
   unspecified(0),
   immediate_commit(1),
   random_delay(2),
-  preference_wheel(3),
-  designated_committer(4),
-  tree_proximity(5)
   (255)
 } PendingProposalStrategy;
 
 struct {
   PendingProposalStrategy pending_proposal_strategy;
-  uint64 minimum_delay_ms;
-  uint64 maximum_delay_ms;
+  select (pending_proposal_strategy) {
+    case unspecified:
+      struct {};
+    case immediate_commit:
+      struct {};
+    case random_delay:
+      uint64 minimum_delay_ms;
+      uint64 maximum_delay_ms;
+    case extension:
+      ComponentID id_of_strategy_params;
+  }
 } PendingProposalPolicy;
 
 struct {
@@ -703,7 +709,6 @@ struct {
   uint64 default_time;
   uint64 maximum_time;
 } MinDefaultMaxTime;
-
 
 struct {
   uint8  epoch_tolerance;
@@ -733,6 +738,10 @@ struct {
 OperationalParameters OperationalParametersData;
 OperationalParameters OperationalParametersUpdate;
 ~~~
+
+
+
+
 
 ## Not relevant to MIMI (between client and its provider)
 
@@ -2014,16 +2023,22 @@ enum {
   unspecified(0),
   immediate_commit(1),
   random_delay(2),
-  preference_wheel(3),
-  designated_committer(4),
-  tree_proximity(5)
   (255)
 } PendingProposalStrategy;
 
 struct {
   PendingProposalStrategy pending_proposal_strategy;
-  uint64 minimum_delay_ms;
-  uint64 maximum_delay_ms;
+  select (pending_proposal_strategy) {
+    case unspecified:
+      struct {};
+    case immediate_commit:
+      struct {};
+    case random_delay:
+      uint64 minimum_delay_ms;
+      uint64 maximum_delay_ms;
+    case extension:
+      ComponentID id_of_strategy_params;
+  }
 } PendingProposalPolicy;
 
 struct {


### PR DESCRIPTION
- split the list of active JoinLinks from the JoinLinkPolicy\
- simplify PendingProposalStrategy
- rename policy_component_ids. BasePolicy contains a list of Component ID numbers, no actual components.